### PR TITLE
chore(docker): add multi-stage Dockerfiles and full compose stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DB_PASSWORD=your_secure_password_here

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,62 @@
 services:
-    sqlserver:
-        image: mcr.microsoft.com/mssql/server:2025-latest
-        container_name: realtime-dashboard-db
-        environment:
-            SA_PASSWORD: "Dev_Password_123!"
-            ACCEPT_EULA: "Y"
-            MSSQL_PID: "Developer"
-        ports:
-            - "1433:1433"
-        volumes:
-            - sqlserver_data:/var/opt/mssql
-        healthcheck:
-            test: ["CMD", "/opt/mssql-tools/bin/sqlcmd", "-S", "localhost", "-U", "sa", "-P", "Dev_Password_123!", "-Q", "SELECT 1"]
-            interval: 10s
-            timeout: 5s
-            retries: 5
+  sqlserver:
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    container_name: realtime-db
+    environment:
+      SA_PASSWORD: "${DB_PASSWORD}"
+      ACCEPT_EULA: "Y"
+      MSSQL_PID: "Developer"
+    ports:
+      - "1433:1433"
+    volumes:
+      - sqlserver_data:/var/opt/mssql
+    healthcheck:
+      test: ["CMD-SHELL", "grep -q 'SQL Server is now ready' /var/opt/mssql/log/errorlog"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    networks:
+      - dashboard-net
+
+  api:
+    build:
+      context: .
+      dockerfile: src/RealtimeDashboard.API/Dockerfile
+    container_name: realtime-api
+    environment:
+      ASPNETCORE_ENVIRONMENT: "Production"
+      ASPNETCORE_URLS: "http://+:8080"
+      ConnectionStrings__DefaultConnection: >
+        Server=sqlserver,1433;
+        Database=RealtimeDashboard;
+        User Id=sa;
+        Password=${DB_PASSWORD};
+        TrustServerCertificate=True
+      Cors__AllowedOrigins: "http://localhost:3000"
+    ports:
+      - "5000:8080"
+    depends_on:
+      sqlserver:
+        condition: service_healthy
+    networks:
+      - dashboard-net
+
+  client:
+    build:
+      context: .
+      dockerfile: src/RealtimeDashboard.Client/Dockerfile
+    container_name: realtime-client
+    ports:
+      - "3000:80"
+    depends_on:
+      - api
+    networks:
+      - dashboard-net
+
 volumes:
-    sqlserver_data:
+  sqlserver_data:
+
+networks:
+  dashboard-net:
+    driver: bridge

--- a/src/RealtimeDashboard.API/Dockerfile
+++ b/src/RealtimeDashboard.API/Dockerfile
@@ -1,0 +1,30 @@
+# Build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY src/RealtimeDashboard.API/RealtimeDashboard.API.csproj src/RealtimeDashboard.API/
+COPY src/RealtimeDashboard.Application/RealtimeDashboard.Application.csproj src/RealtimeDashboard.Application/
+COPY src/RealtimeDashboard.Domain/RealtimeDashboard.Domain.csproj src/RealtimeDashboard.Domain/
+COPY src/RealtimeDashboard.Infrastructure/RealtimeDashboard.Infrastructure.csproj src/RealtimeDashboard.Infrastructure/
+
+RUN dotnet restore "src/RealtimeDashboard.API/RealtimeDashboard.API.csproj"
+
+COPY . .
+
+RUN dotnet build "src/RealtimeDashboard.API/RealtimeDashboard.API.csproj" -c Release -o /app/build --no-restore
+
+# Publish
+FROM build AS publish
+RUN dotnet publish "src/RealtimeDashboard.API/RealtimeDashboard.API.csproj" -c Release -o /app/publish --no-restore /p:UseAppHost=false
+
+# Runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
+WORKDIR /app
+
+RUN useradd --create-home --shell /bin/bash appuser && chown -R appuser:appuser /app
+USER appuser
+
+COPY --from=publish /app/publish .
+
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "RealtimeDashboard.API.dll"]

--- a/src/RealtimeDashboard.API/Program.cs
+++ b/src/RealtimeDashboard.API/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore;
 using RealtimeDashboard.API.Hubs;
 using RealtimeDashboard.API.Middleware;
 using RealtimeDashboard.API.SeedData;
@@ -21,26 +22,19 @@ builder.Services.AddControllers()
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+var allowedOrigins = builder.Configuration
+                         .GetSection("Cors:AllowedOrigins")
+                         .Get<string[]>()
+                     ?? builder.Configuration["Cors:AllowedOrigins"]?.Split(',')
+                     ?? ["http://localhost:5001"];
+
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("BlazorClient", policy =>
-    {
-        if (builder.Environment.IsDevelopment())
-        {
-            policy.SetIsOriginAllowed(origin =>
-                    new Uri(origin).Host == "localhost")
-                .AllowAnyHeader()
-                .AllowAnyMethod()
-                .AllowCredentials();
-        }
-        else
-        {
-            policy.WithOrigins("https://OnVerraMonNomDeDomaine.com")
-                .AllowAnyHeader()
-                .AllowAnyMethod()
-                .AllowCredentials();
-        }
-    });
+        policy.WithOrigins(allowedOrigins)
+            .AllowAnyHeader()
+            .AllowAnyMethod()
+            .AllowCredentials());
 });
 
 var app = builder.Build();
@@ -64,5 +58,34 @@ app.UseSwaggerUI(options =>
 
 app.MapControllers();
 app.MapHub<ResourceHub>("/hubs/resources");
+
+using (var scope = app.Services.CreateScope())
+{
+    var context = scope.ServiceProvider
+        .GetRequiredService<ApplicationDbContext>();
+
+    var retries = 5;
+    while (retries > 0)
+    {
+        try
+        {
+            await context.Database.MigrateAsync();
+
+            if (app.Environment.IsDevelopment())
+                await ApplicationDbContextSeed.SeedAsync(context);
+
+            break;
+        }
+        catch (Exception ex)
+        {
+            retries--;
+            if (retries == 0) throw;
+            app.Logger.LogWarning(
+                "Database not ready, retrying... ({Retries} attempts left). Error: {Error}",
+                retries, ex.Message);
+            await Task.Delay(5000);
+        }
+    }
+}
 
 app.Run();

--- a/src/RealtimeDashboard.API/appsettings.json
+++ b/src/RealtimeDashboard.API/appsettings.json
@@ -2,6 +2,9 @@
   "ConnectionStrings": {
     "DefaultConnection": ""
   },
+  "Cors": {
+    "AllowedOrigins": "http://localhost:5033"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/RealtimeDashboard.Client/Dockerfile
+++ b/src/RealtimeDashboard.Client/Dockerfile
@@ -1,0 +1,19 @@
+# Build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY src/RealtimeDashboard.Client/RealtimeDashboard.Client.csproj src/RealtimeDashboard.Client/
+
+RUN dotnet restore "src/RealtimeDashboard.Client/RealtimeDashboard.Client.csproj"
+
+COPY . .
+
+RUN dotnet publish "src/RealtimeDashboard.Client/RealtimeDashboard.Client.csproj" -c Release -o /app/publish --no-restore
+
+# Nginx
+FROM nginx:alpine AS final
+
+COPY --from=build /app/publish/wwwroot /usr/share/nginx/html
+COPY src/RealtimeDashboard.Client/nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80

--- a/src/RealtimeDashboard.Client/nginx.conf
+++ b/src/RealtimeDashboard.Client/nginx.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types application/wasm application/javascript text/css;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location ~* \.(js|wasm|css|png|ico)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}

--- a/src/RealtimeDashboard.Client/wwwroot/appsettings.Production.json
+++ b/src/RealtimeDashboard.Client/wwwroot/appsettings.Production.json
@@ -1,0 +1,4 @@
+{
+  "ApiBaseUrl": "http://localhost:5000",
+  "HubUrl": "http://localhost:5000/hubs/resources"
+}


### PR DESCRIPTION
- Add multi-stage Dockerfile for API (sdk:10.0 build + aspnet:10.0 runtime)
- Add multi-stage Dockerfile for Blazor client (sdk:10.0 build + nginx:alpine)
- Add nginx.conf for Blazor SPA routing and WASM compression
- Update docker-compose.yml with 3 services (sqlserver, api, client)
- Add .env.example for environment variable documentation
- Add automatic DB migration with retry logic on API startup
- Configure CORS from environment/config (not hardcoded)
- Update README Getting Started with Docker instructions